### PR TITLE
added proper label for jawsdb

### DIFF
--- a/config/database.js
+++ b/config/database.js
@@ -2,7 +2,7 @@ const mysql = require("mysql2");
 require("dotenv").config();
 
 const db = mysql.createConnection(
-    process.env.JAWSDB_URL
+    process.env.JAWSDB_SILVER_URL
 );
 
 db.connect((err) => {


### PR DESCRIPTION
fixed heroku deploy, tag for jaws_db wasnt set correctly needs silver added. new merge fixes issue then i need to deploy on heroku from mian branch again. local instance still works.